### PR TITLE
Add uvicorn serve script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ A self hostable docker application that lets you make custom group lists of subr
 2. docker compose up --build -d
 3. Go to the ports you selected (default is 5015 for frontend and 8015 for backend API)
 
+If you just want to run the API locally without Docker you can start it with
+`serve_api.py`. This script loads `.env` and falls back to sensible defaults:
+
+```bash
+python serve_api.py
+```
+
+It uses `API_HOST` and `API_PORT` from your `.env` file if they are set.
+
 ENJOY!
 
 ## What can you do with it? 

--- a/serve_api.py
+++ b/serve_api.py
@@ -1,0 +1,13 @@
+import os
+from dotenv import load_dotenv
+from api_main import app
+
+load_dotenv()
+
+HOST = os.getenv("API_HOST", "0.0.0.0")
+PORT = int(os.getenv("API_PORT", 8015))
+LOG_LEVEL = os.getenv("LOG_LEVEL", "info").lower()
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host=HOST, port=PORT, log_level=LOG_LEVEL)


### PR DESCRIPTION
## Summary
- create `serve_api.py` so the API can be started with uvicorn using environment variables
- document usage in the README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68849fb948348326aa483c555c53e2e7